### PR TITLE
Update build.gradle

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -32,14 +32,14 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
 
-    compile 'com.google.firebase:firebase-messaging:17.3.4'
-    compile "com.android.support:support-v4:27.1.1"
-    compile 'com.android.volley:volley:1.1.1'
+    implementation 'com.google.firebase:firebase-messaging:17.3.4'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.volley:volley:1.1.1'
     // Encrypted shared preferences
-    compile 'com.scottyab:secure-preferences-lib:0.1.4'
+    implementation 'com.scottyab:secure-preferences-lib:0.1.4'
 }
 
 


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html